### PR TITLE
Accept all known secret types for the Decryption Secrets Block (DSB)

### DIFF
--- a/pcapgo/ngread_dsb_test.go
+++ b/pcapgo/ngread_dsb_test.go
@@ -2,7 +2,7 @@ package pcapgo
 
 import (
 	"fmt"
-	"github.com/google/gopacket"
+	"github.com/gopacket/gopacket"
 	"io"
 	"os"
 	"testing"

--- a/pcapgo/ngwrite_dsb.go
+++ b/pcapgo/ngwrite_dsb.go
@@ -71,10 +71,7 @@ type pcapngDecryptionSecretsBlock struct {
 func (w *NgWriter) WriteDecryptionSecretsBlock(secretType uint32, secretPayload []byte) error {
 
 	switch secretType {
-	case DSB_SECRETS_TYPE_SSH, DSB_SECRETS_TYPE_ZIGBEE_NWK_KEY, DSB_SECRETS_TYPE_WIREGUARD, DSB_SECRETS_TYPE_ZIGBEE_APS_KEY:
-		// unsupported secrets type
-		return ErrUnsupportedSecretsType
-	case DSB_SECRETS_TYPE_TLS:
+	case DSB_SECRETS_TYPE_SSH, DSB_SECRETS_TYPE_ZIGBEE_NWK_KEY, DSB_SECRETS_TYPE_WIREGUARD, DSB_SECRETS_TYPE_ZIGBEE_APS_KEY, DSB_SECRETS_TYPE_TLS:
 	default:
 		// unknown secrets type
 		return ErrUnknownSecretsType
@@ -95,7 +92,7 @@ func (w *NgWriter) WriteDecryptionSecretsBlock(secretType uint32, secretPayload 
 	binary.LittleEndian.PutUint32(w.buf[4:8], length)
 
 	// write decryption secrets block
-	binary.LittleEndian.PutUint32(w.buf[8:12], DSB_SECRETS_TYPE_TLS)
+	binary.LittleEndian.PutUint32(w.buf[8:12], secretType)
 	binary.LittleEndian.PutUint32(w.buf[12:16], uint32(secretPayloadLen))
 
 	if _, err := w.w.Write(w.buf[:16]); err != nil {

--- a/pcapgo/ngwrite_dsb_test.go
+++ b/pcapgo/ngwrite_dsb_test.go
@@ -2,7 +2,7 @@ package pcapgo
 
 import (
 	"fmt"
-	"github.com/google/gopacket/layers"
+	"github.com/gopacket/gopacket/layers"
 	"io"
 	"math"
 	"net"

--- a/pcapgo/pcapng.go
+++ b/pcapgo/pcapng.go
@@ -54,8 +54,7 @@ const (
 
 // define error types for DSB
 var (
-	ErrUnsupportedSecretsType = errors.New("Unsupported Decryption Secrets Block (DSB) type")
-	ErrUnknownSecretsType     = errors.New("Unknown Decryption Secrets Block (DSB) type")
+	ErrUnknownSecretsType = errors.New("Unknown Decryption Secrets Block (DSB) type")
 )
 
 type ngOptionCode uint16


### PR DESCRIPTION
I cant see a reason that the current implementation should not apply to the other existing secret types.

We might want to add more specialized functions to add specific secrets.
But the generic version should be okay for all.